### PR TITLE
start postfix in `anonaddy` container (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Start postfix in `anonaddy` container (#10)
+
 ## 0.2.4-RC1 (2020/02/29)
 
 * AnonAddy 0.2.4

--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - anonaddy
     ports:
       - target: 2500
-        published: 2500
+        published: 25
         protocol: tcp
     volumes:
       - "./data:/data"

--- a/rootfs/etc/cont-init.d/04-svc-main.sh
+++ b/rootfs/etc/cont-init.d/04-svc-main.sh
@@ -7,6 +7,9 @@ if [ "$SIDECAR_CRON" = "1" ] || [ "$SIDECAR_POSTFIX" = "1" ]; then
   exit 0
 fi
 
+# Start the postfix service to be able to send mail
+postfix start
+
 # Migrate
 su-exec anonaddy:anonaddy php artisan migrate --no-interaction --force
 su-exec anonaddy:anonaddy php artisan cache:clear --no-interaction


### PR DESCRIPTION
Changes as described in issue #10

I don't know if this should be done this way, as there already is a postfix container (for accepting mail?).